### PR TITLE
Update portfolio content to reflect current PM role

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -61,7 +61,7 @@ const Header = ({ resumeData }) => {
         <div className="row banner">
           <div className="banner-text">
             <h1 className="responsive-headline">{resumeData.name}</h1>
-            <h3 style={{ color: '#fff', fontFamily: 'sans-serif' }}>I am a {resumeData.role}.{resumeData.roleDescription ? ` ${resumeData.roleDescription}` : ''}</h3>
+            <h3 style={{ color: '#fff', fontFamily: 'sans-serif' }}>{resumeData.roleDescription || `I am a ${resumeData.role}.`}</h3>
             <hr />
             <ul className="social">
               {

--- a/src/components/Portfolio.js
+++ b/src/components/Portfolio.js
@@ -5,21 +5,25 @@ const Portfolio = ({ resumeData }) => {
     <section id="portfolio">
       <div className="row">
         <div className="twelve columns collapsed">
-          <h1>Here is a selection of my work:</h1>
+          <h1>What I've Built</h1>
           <div id="portfolio-wrapper" className="bgrid-halves cf">
             {
               resumeData.portfolio && resumeData.portfolio.map((item) => (
                 <div key={item.name} className="columns portfolio-item">
                   <div className="item-wrap">
-                    <a href={item.projurl} target="_blank" rel="noopener noreferrer">
+                    {item.projurl ? (
+                      <a href={item.projurl} target="_blank" rel="noopener noreferrer">
+                        <img src={`${process.env.PUBLIC_URL}/${item.imgurl}`} className="item-img" alt={item.name} />
+                      </a>
+                    ) : (
                       <img src={`${process.env.PUBLIC_URL}/${item.imgurl}`} className="item-img" alt={item.name} />
-                    </a>
+                    )}
                     <div className="overlay">
-                      <a href={item.projurl} target="_blank" rel="noopener noreferrer" className="portfolio-item-meta" style={{ display: 'block' }}>
+                      <div className="portfolio-item-meta" style={{ display: 'block' }}>
                         <h5>{item.name}</h5>
                         <p>{item.description}</p>
-                      </a>
-                      <p><a href={item.repo} target="_blank" rel="noopener noreferrer">Github Repository</a></p>
+                      </div>
+                      {item.repo && <p><a href={item.repo} target="_blank" rel="noopener noreferrer">Github Repository</a></p>}
                     </div>
                   </div>
                 </div>

--- a/src/resumeData.js
+++ b/src/resumeData.js
@@ -1,6 +1,7 @@
 let resumeData = {
   "name": "Ben Calvert",
   "role": "Senior Product Manager",
+  "roleDescription": "I build products at the intersection of AI, data, and K-12 education — turning complex problems into scalable solutions that serve millions of families.",
   "linkedinId": "https://linkedin.com/in/benjamin-calvert-62978438/",
   "email": "mailto:benhcalvert@gmail.com",
   "socialLinks": [
@@ -15,7 +16,7 @@ let resumeData = {
       "className": "fa fa-github"
     }
   ],
-  "aboutme": "Data-driven Senior Product Manager with a background in full-stack engineering and K-12 education operations. I specialize in bridging the gap between technical requirements and user experience — having worked as both an engineer and a PM at ParentSquare, an EdTech platform serving K-12 schools nationwide. Proven track record of launching 0-to-1 products and leading cross-functional teams to reduce support volume and COGS. Based in Boise, ID.",
+  "aboutme": "I'm a Senior Product Manager at ParentSquare, where I lead teams building the communication platform used by 20M+ families across U.S. school districts. I've shipped 0-to-1 products that quickly generated $1M+ in new ARR, pioneered an agentic AI product discovery process, and driven 70%+ reductions in support volume through better UX. Before product, I was an integration engineer and before that, I ran school operations . I think about problems from the code, the user, and the business all at once. Based in Boise, ID.",
   "address": "Boise, ID",
   "website": "https://github.com/BenHCalvert",
   "education": [
@@ -81,50 +82,40 @@ let resumeData = {
   ],
   "skillsDescription": "Skills",
   "skills": [
-    { "skillname": "Agile/Scrum" },
-    { "skillname": "ShapeUp" },
+    { "skillname": "AI/LLM Product Development" },
+    { "skillname": "0-to-1 Product Launches" },
+    { "skillname": "Product Analytics" },
     { "skillname": "User Research" },
+    { "skillname": "Go-to-Market Strategy" },
+    { "skillname": "Agile/Scrum" },
     { "skillname": "Figma" },
     { "skillname": "Pendo" },
     { "skillname": "Jira" },
-    { "skillname": "Notion" },
-    { "skillname": "GTM" },
+    { "skillname": "SQL" },
+    { "skillname": "Claude / Anthropic" },
     { "skillname": "JavaScript" },
-    { "skillname": "HTML" },
-    { "skillname": "MySQL" },
-    { "skillname": "AWS" },
-    { "skillname": "GitHub" },
-    { "skillname": "Ruby on Rails" },
-    { "skillname": "Cloudflare" }
+    { "skillname": "API & Data Integrations" }
   ],
   "portfolio": [
     {
-      "name": "Cloudflare Workers Linktree",
-      "description": "A serverless edge computing project built on Cloudflare Workers that serves a dynamic linktree-style page by fetching links from a JSON API endpoint.",
-      "projurl": "https://my-app.benhcalvert.workers.dev/",
-      "imgurl": "images/portfolio/cfworkers.png",
-      "repo": "https://github.com/BenHCalvert/CFProj"
+      "name": "Agentic Product Discovery",
+      "description": "Designed and implemented an AI-powered product discovery workflow using Claude to synthesize user research, support data, and usage analytics — accelerating insight generation and reducing discovery cycle time for the ParentSquare product team.",
+      "imgurl": "images/portfolio/agentic-discovery.png"
     },
     {
-      "name": "Hike & Dinner",
-      "description": "A JavaScript app that helps users find a nearby hike and a restaurant close to the trailhead, using the Google Maps and Yelp APIs.",
-      "projurl": "https://benhcalvert.github.io/Group-Project/",
-      "imgurl": "images/portfolio/HikeandDinner_2.png",
-      "repo": "https://github.com/BenHCalvert/Group-Project"
+      "name": "Virtual Phone: 0-to-1 Launch",
+      "description": "Led end-to-end product development and GTM for ParentSquare's Virtual Phone product — from discovery through launch — generating $1M+ in new ARR within 20 months.",
+      "imgurl": "images/portfolio/virtual-phone.png"
     },
     {
-      "name": "Weather Dashboard",
-      "description": "A weather dashboard with 5-day forecast built with vanilla JavaScript and the OpenWeather API.",
-      "projurl": "https://benhcalvert.github.io/HW6_Weather/",
-      "imgurl": "images/portfolio/WeatherDashboard_2.png",
-      "repo": "https://github.com/BenHCalvert/HW6_Weather"
+      "name": "Admin UX & Integrations Platform",
+      "description": "Formed and led a new product team focused on platform integrations and admin experience, reducing support ticket volume by 70%+ across key categories in the first year.",
+      "imgurl": "images/portfolio/admin-ux.png"
     },
     {
-      "name": "GitHub Profile PDF Generator",
-      "description": "A Node.js command line tool that generates a formatted PDF profile card from any GitHub username.",
-      "projurl": "https://github.com/BenHCalvert/DevProfileGen",
-      "imgurl": "images/portfolio/DevProfileGen.gif",
-      "repo": "https://github.com/BenHCalvert/DevProfileGen"
+      "name": "EdTech Data Integrations",
+      "description": "Architected integrations with SIS platforms serving hundreds of school districts, ensuring seamless data interoperability and streamlining district onboarding as an integration engineer turned PM.",
+      "imgurl": "images/portfolio/data-integrations.png"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Rewrites hero subtitle with a positioning statement around AI, data, and K-12 education
- Updates About Me with new copy reflecting current role, impact metrics, and career arc
- Overhauled skills section — removed bootcamp-era tools (Ruby on Rails, HTML, MySQL, Cloudflare) and replaced with current PM skills (AI/LLM Product Development, Product Analytics, GTM, Claude/Anthropic)
- Replaced 4 bootcamp dev projects in Portfolio with PM case studies (Agentic Product Discovery, Virtual Phone launch, Admin UX & Integrations, EdTech Data Integrations)
- Updated Portfolio component to handle items without live URLs/repos gracefully

## Test plan
- [x] Build compiles cleanly (`NODE_OPTIONS=--openssl-legacy-provider npm run build`)
- [x] Hero subtitle displays new positioning statement
- [x] About Me displays updated copy
- [x] Skills section shows updated list
- [x] Portfolio section shows 4 case studies without broken links
- [ ] Add placeholder images for portfolio case studies (`images/portfolio/agentic-discovery.png`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)